### PR TITLE
Only set owner/group to elasticsearch if needed

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,11 +26,6 @@ class elasticsearch::config {
 
   #### Configuration
 
-  File {
-    owner => $elasticsearch::elasticsearch_user,
-    group => $elasticsearch::elasticsearch_group,
-  }
-
   Exec {
     path => [ '/bin', '/usr/bin', '/usr/local/bin' ],
     cwd  => '/',
@@ -50,7 +45,7 @@ class elasticsearch::config {
 
     file { $elasticsearch::logdir:
       ensure  => 'directory',
-      group   => undef,
+      owner   => $elasticsearch::elasticsearch_user,
       mode    => '0644',
       recurse => true,
     }
@@ -60,7 +55,9 @@ class elasticsearch::config {
     }
 
     file { $elasticsearch::datadir:
-      ensure  => 'directory',
+      ensure => 'directory',
+      owner  => $elasticsearch::elasticsearch_user,
+      group  => $elasticsearch::elasticsearch_group,
     }
 
     file { "${elasticsearch::homedir}/lib":
@@ -71,7 +68,7 @@ class elasticsearch::config {
     if $elasticsearch::params::pid_dir {
       file { $elasticsearch::params::pid_dir:
         ensure  => 'directory',
-        group   => undef,
+        owner   => $elasticsearch::elasticsearch_user,
         recurse => true,
       }
 

--- a/spec/acceptance/020_usergroup_spec.rb
+++ b/spec/acceptance/020_usergroup_spec.rb
@@ -50,7 +50,6 @@ describe "elasticsearch class:" do
 
     describe file('/usr/share/elasticsearch') do
       it { should be_directory }
-      it { should be_owned_by 'esuser' }
     end
 
     describe file('/var/log/elasticsearch') do
@@ -60,7 +59,6 @@ describe "elasticsearch class:" do
 
     describe file('/etc/elasticsearch') do
       it { should be_directory }
-      it { should be_owned_by 'esuser' }
     end
 
 

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -308,9 +308,9 @@ describe 'elasticsearch', :type => 'class' do
           })
         }
 
-        it { should contain_file('/etc/elasticsearch').with(:owner => 'myesuser', :group => 'myesgroup') }
+        it { should contain_file('/etc/elasticsearch') }
         it { should contain_file('/var/log/elasticsearch').with(:owner => 'myesuser') }
-        it { should contain_file('/usr/share/elasticsearch').with(:owner => 'myesuser', :group => 'myesgroup') }
+        it { should contain_file('/usr/share/elasticsearch') }
         # it { should contain_file('/usr/share/elasticsearch/plugins').with(:owner => 'myesuser', :group => 'myesgroup') }
         it { should contain_file('/usr/share/elasticsearch/data').with(:owner => 'myesuser', :group => 'myesgroup') }
         it { should contain_file('/var/run/elasticsearch').with(:owner => 'myesuser') } if facts[:osfamily] == 'RedHat'


### PR DESCRIPTION
Otherwise, binaries and plugins can be hijacked if arbitrary code is executed.
