### PR TITLE
pid directory mode needs be writable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -88,6 +88,7 @@ class elasticsearch::config {
         ensure  => 'directory',
         group   => undef,
         owner   => $elasticsearch::elasticsearch_user,
+        mode    => '0755',
         recurse => true,
       }
 


### PR DESCRIPTION
Employer EnableIT

If file resource is defined globally, its fails to start the elasticsearch process. so getting the mode set in first place is a right way to do it.

```
File { owner => root, group => root, mode => '0444' }
```
