### PR TITLE
add lifecycle snapshot management

### DIFF
--- a/lib/puppet/provider/elasticsearch_snapshot_lifecycle_policy/ruby.rb
+++ b/lib/puppet/provider/elasticsearch_snapshot_lifecycle_policy/ruby.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:elasticsearch_snapshot_lifecycle_policy).provide(
   mk_resource_methods
 
   def self.process_body(body)
-    Puppet.info('Got to snapshot_lifecycle_policy.process_body')
+    Puppet.debug('Got to snapshot_lifecycle_policy.process_body')
 
     results = JSON.parse(body).map do |object_name, api_object|
       {
@@ -31,7 +31,6 @@ Puppet::Type.type(:elasticsearch_snapshot_lifecycle_policy).provide(
         :provider                     => name
       }.reject { |_k, v| v.nil? }
     end
-    Puppet.info(results)
     results
   end
 

--- a/lib/puppet/provider/elasticsearch_snapshot_lifecycle_policy/ruby.rb
+++ b/lib/puppet/provider/elasticsearch_snapshot_lifecycle_policy/ruby.rb
@@ -42,8 +42,8 @@ Puppet::Type.type(:elasticsearch_snapshot_lifecycle_policy).provide(
       'schedule'    => resource[:schedule_time],
       'repository'  => resource[:repository],
       'name'        => resource[:snapshot_name],
-      'config'      => { },
-      'retention'   => { }
+      'config'      => {},
+      'retention'   => {}
     }
 
     # Add optional values

--- a/lib/puppet/provider/elasticsearch_snapshot_lifecycle_policy/ruby.rb
+++ b/lib/puppet/provider/elasticsearch_snapshot_lifecycle_policy/ruby.rb
@@ -1,0 +1,61 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..'))
+
+require 'puppet/provider/elastic_rest'
+
+Puppet::Type.type(:elasticsearch_snapshot_lifecycle_policy).provide(
+  :ruby,
+  :parent => Puppet::Provider::ElasticREST,
+  :api_uri => '_slm/policy'
+) do
+  desc 'A REST API based provider to manage Elasticsearch snapshot lifecycle policy.'
+
+  mk_resource_methods
+
+  def self.process_body(body)
+    Puppet.info('Got to snapshot_lifecycle_policy.process_body')
+
+    results = JSON.parse(body).map do |object_name, api_object|
+      {
+        :name                         => object_name,
+        :ensure                       => :present,
+        :schedule_time                => api_object['policy']['schedule'],
+        :repository                   => api_object['policy']['repository'],
+        :snapshot_name                => api_object['policy']['name'],
+        :config_include_global_state  => api_object['policy']['config']['include_global_state'],
+        :config_ignore_unavailable    => api_object['policy']['config']['ignore_unavailable'],
+        :config_partial               => api_object['policy']['config']['partial'],
+        :config_indices               => api_object['policy']['config']['indices'],
+        :retention_expire_after       => api_object['policy']['retention']['expire_after'],
+        :retention_min_count          => api_object['policy']['retention']['min_count'],
+        :retention_max_count          => api_object['policy']['retention']['max_count'],
+        :provider                     => name
+      }.reject { |_k, v| v.nil? }
+    end
+    Puppet.info(results)
+    results
+  end
+
+  def generate_body
+    Puppet.debug('Got to snapshot_lifecycle_policy.generate_body')
+    # Build core request body
+    body = {
+      'schedule'    => resource[:schedule_time],
+      'repository'  => resource[:repository],
+      'name'        => resource[:snapshot_name],
+      'config'      => { },
+      'retention'   => { }
+    }
+
+    # Add optional values
+    body['config']['include_global_state'] = resource[:config_include_global_state] unless resource[:config_include_global_state].nil?
+    body['config']['ignore_unavailable'] = resource[:config_ignore_unavailable] unless resource[:config_ignore_unavailable].nil?
+    body['config']['partial'] = resource[:config_partial] unless resource[:config_partial].nil?
+    body['config']['indices'] = resource[:config_indices] unless resource[:config_indices].nil?
+    body['retention']['expire_after'] = resource[:retention_expire_after] unless resource[:retention_expire_after].nil?
+    body['retention']['min_count'] = resource[:retention_min_count] unless resource[:retention_min_count].nil?
+    body['retention']['max_count'] = resource[:retention_max_count] unless resource[:retention_max_count].nil?
+
+    # Convert to JSON and return
+    JSON.generate(body)
+  end
+end

--- a/lib/puppet/type/elasticsearch_snapshot_lifecycle_policy.rb
+++ b/lib/puppet/type/elasticsearch_snapshot_lifecycle_policy.rb
@@ -1,0 +1,67 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..'))
+
+require 'puppet_x/elastic/elasticsearch_rest_resource'
+
+Puppet::Type.newtype(:elasticsearch_snapshot_lifecycle_policy) do
+  extend ElasticsearchRESTResource
+
+  desc 'Manages Elasticsearch snapshot lifecycle policies.'
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc 'Lifecycle policy name.'
+  end
+
+  newproperty(:schedule_time) do
+    desc 'Schedule'
+  end
+
+  newproperty(:repository) do
+    desc 'Repository name'
+  end
+
+  newproperty(:snapshot_name) do
+    desc 'Snapshot name'
+  end
+
+  newproperty(:config_include_global_state, :boolean => false) do
+    desc 'Include global state'
+
+    defaultto :false
+  end
+
+  newproperty(:config_ignore_unavailable, :boolean => false) do
+    desc 'Ignore unavailable shards'
+
+    defaultto :false
+  end
+
+  newproperty(:config_partial, :boolean => false) do
+    desc 'Allow partial snapshots'
+
+    defaultto :false
+  end
+
+  newproperty(:config_indices) do
+    desc 'Indices to snapshot'
+  end
+
+  newproperty(:retention_expire_after) do
+    desc 'Expire snapshots after time'
+  end
+
+  newproperty(:retention_min_count) do
+    desc 'Minimum snapshots'
+  end
+
+  newproperty(:retention_max_count) do
+    desc 'Maximum snaphots'
+  end
+
+  validate do
+    raise ArgumentError, 'schedule_time is required.' if self[:schedule_time].nil?
+    raise ArgumentError, 'repository is required.' if self[:repository].nil?
+    raise ArgumentError, 'snapshot_name is required.' if self[:snapshot_name].nil?
+  end
+end # of newtype

--- a/manifests/snapshot_lifecycle_policy.pp
+++ b/manifests/snapshot_lifecycle_policy.pp
@@ -1,0 +1,118 @@
+#  This define allows you to insert, update or delete Elasticsearch snapshot
+#  lifecycle policy.
+#
+# @param ensure
+#   Controls whether the named index template should be present or absent in
+#   the cluster.
+#
+# @param api_basic_auth_password
+#   HTTP basic auth password to use when communicating over the Elasticsearch
+#   API.
+#
+# @param api_basic_auth_username
+#   HTTP basic auth username to use when communicating over the Elasticsearch
+#   API.
+#
+# @param api_ca_file
+#   Path to a CA file which will be used to validate server certs when
+#   communicating with the Elasticsearch API over HTTPS.
+#
+# @param api_ca_path
+#   Path to a directory with CA files which will be used to validate server
+#   certs when communicating with the Elasticsearch API over HTTPS.
+#
+# @param api_host
+#   Host name or IP address of the ES instance to connect to.
+#
+# @param api_port
+#   Port number of the ES instance to connect to
+#
+# @param api_protocol
+#   Protocol that should be used to connect to the Elasticsearch API.
+#
+# @param api_timeout
+#   Timeout period (in seconds) for the Elasticsearch API.
+#
+# @param schedule_time
+#   Periodic or absolute schedule at which the policy creates snapshots and deletes expired snapshots
+#
+# @param repository
+#   Repository used to store snapshots created by this policy.
+#
+# @param snapshot_name
+#   Name of the snapshots
+#
+# @param config_include_global_state
+#   If true, cluster states are included in snapshots. Defaults to false. 
+#
+# @param config_ignore_unavailable
+#   If true, missing indices do not cause snapshot creation to fail and return an error. Defaults to false. 
+#
+# @param config_partial
+#   Allow partial snapshots
+#
+# @param config_indices
+#   Array of index names or wildcard pattern of index names included in snapshots. 
+#
+# @param retention_expire_after
+#   Time period after which a snapshot is considered expired and eligible for deletion. 
+#
+# @param retention_min_count
+#   Minimum number of snapshots to retain, even if the snapshots have expired. 
+#
+# @param retention_max_count
+#   Maximum number of snapshots to retain, even if the snapshots have not yet expired. 
+#   If the number of snapshots in the repository exceeds this limit, the policy retains the most recent snapshots and deletes older snapshots. 
+#
+# @author Thomas Manninger
+define elasticsearch::snapshot_lifecycle_policy (
+  Enum['absent', 'present']       $ensure                       = 'present',
+  Optional[String]                $api_basic_auth_password      = $elasticsearch::api_basic_auth_password,
+  Optional[String]                $api_basic_auth_username      = $elasticsearch::api_basic_auth_username,
+  Optional[Stdlib::Absolutepath]  $api_ca_file                  = $elasticsearch::api_ca_file,
+  Optional[Stdlib::Absolutepath]  $api_ca_path                  = $elasticsearch::api_ca_path,
+  String                          $api_host                     = $elasticsearch::api_host,
+  Integer[0, 65535]               $api_port                     = $elasticsearch::api_port,
+  Enum['http', 'https']           $api_protocol                 = $elasticsearch::api_protocol,
+  Integer                         $api_timeout                  = $elasticsearch::api_timeout,
+  Boolean                         $validate_tls                 = $elasticsearch::validate_tls,
+  String                          $schedule_time,
+  String                          $repository,
+  String                          $snapshot_name                = "<${name}-{now/d}>",
+  Boolean                         $config_include_global_state  = false,
+  Boolean                         $config_ignore_unavailable    = false,
+  Boolean                         $config_partial               = false,
+  Array[String]                   $config_indices               = [ '*', 'test' ],
+  Optional[String]                $retention_expire_after       = undef,
+  Optional[Integer]               $retention_min_count          = undef,
+  Optional[Integer]               $retention_max_count          = undef,
+) {
+
+  es_instance_conn_validator { "${name}-snapshot_lifecycle_policy":
+    server  => $api_host,
+    port    => $api_port,
+    timeout => $api_timeout,
+  }
+  -> elasticsearch_snapshot_lifecycle_policy { $name:
+    ensure                        => $ensure,
+    schedule_time                 => $schedule_time,
+    repository                    => $repository,
+    snapshot_name                 => $snapshot_name,
+    config_include_global_state   => $config_include_global_state,
+    config_ignore_unavailable     => $config_ignore_unavailable,
+    config_partial                => $config_partial,
+    config_indices                => $config_indices,
+    retention_expire_after        => $retention_expire_after,
+    retention_min_count           => $retention_min_count,
+    retention_max_count           => $retention_max_count,
+    protocol                      => $api_protocol,
+    host                          => $api_host,
+    port                          => $api_port,
+    timeout                       => $api_timeout,
+    username                      => $api_basic_auth_username,
+    password                      => $api_basic_auth_password,
+    ca_file                       => $api_ca_file,
+    ca_path                       => $api_ca_path,
+    validate_tls                  => $validate_tls,
+  }
+}


### PR DESCRIPTION
This PR adds support for manage snapshot lifecycle snapshots

Example:
```
    elasticsearch::snapshot_lifecycle_policy { 'daily_snapshot':
      schedule_time                 => '0 30 0 * * ?',
      repository                    => 's3_repository',
      config_include_global_state   => true,
      config_ignore_unavailable     => true,
      config_partial                => true,
      retention_expire_after        => '90d',
      retention_min_count           => 30
    }
```