### PR TITLE
Fixed Service definition with custom service_name

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -69,7 +69,7 @@ class elasticsearch::config {
         owner  => 'root',
         group  => $elasticsearch::elasticsearch_group,
         mode   => '0660',
-        before => Service['elasticsearch'],
+        before => Service[$elasticsearch::service_name],
         notify => $elasticsearch::_notify_service,
       }
     } else {
@@ -77,7 +77,7 @@ class elasticsearch::config {
         incl    => "${elasticsearch::defaults_location}/elasticsearch",
         lens    => 'Shellvars.lns',
         changes => template("${module_name}/etc/sysconfig/defaults.erb"),
-        before  => Service['elasticsearch'],
+        before  => Service[$elasticsearch::service_name],
         notify  => $elasticsearch::_notify_service,
       }
     }


### PR DESCRIPTION
When Elasticsearch is installed with a custom service_name, puppet will fail because the custom name is not used for the before relationship metaparameter.

```
class { 'elasticsearch':
  service_name        => 'elasticsearch_default',
}
```

results in:
`Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Could not find resource 'Service[elasticsearch]' in parameter 'before'`

<!-- The following list of checkboxes are the prerequisites for getting your contribution accepted. Please check them as they are completed. -->

Pull request acceptance prerequisites:

- [X] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [X] Rebased/up-to-date with base branch
- [ ] Tests pass
- [X] Updated CHANGELOG.md with patch notes (if necessary)
- [x] Updated CONTRIBUTORS (if attribution is requested)
