### PR TITLE
fix restart_on_change behavior

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -511,7 +511,7 @@ class elasticsearch (
     # Installation, configuration and service
     Class['elasticsearch::package']
     -> Class['elasticsearch::config']
-    ~> Class['elasticsearch::service']
+    -> Class['elasticsearch::service']
 
     # Top-level ordering bindings for resources.
     Class['elasticsearch::config']


### PR DESCRIPTION
`restart_on_change` parameter is ignored. If config file is modified, the class `elasticsearch::config` always notify `elasticsearch::service` and the elasticsearch service is being restarted