### PR TITLE
Do not restart Elasticsearch on config change when restart_config_change is set to false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -511,7 +511,12 @@ class elasticsearch (
     # Installation, configuration and service
     Class['elasticsearch::package']
     -> Class['elasticsearch::config']
-    ~> Class['elasticsearch::service']
+
+    if $restart_config_change {
+      Class['elasticsearch::config'] ~> Class['elasticsearch::service']
+    } else {
+      Class['elasticsearch::config'] -> Class['elasticsearch::service']
+    }
 
     # Top-level ordering bindings for resources.
     Class['elasticsearch::config']


### PR DESCRIPTION
This change will fix that Elasticsearch service is not being restarted when `restart_config_change` is set to `false`. Without this change Elasticsearch was still restarted on config changes even when `restart_config_change` was set to `false`. See also issue #1113 
