### PR TITLE
Add option to set private key type

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -128,11 +128,12 @@ class elasticsearch::config {
 
       # Load node certificate and private key
       java_ks { 'elasticsearch_node':
-        ensure      => 'latest',
-        certificate => $elasticsearch::certificate,
-        private_key => $elasticsearch::private_key,
-        target      => $_keystore_path,
-        password    => $elasticsearch::keystore_password,
+        ensure           => 'latest',
+        certificate      => $elasticsearch::certificate,
+        private_key      => $elasticsearch::private_key,
+        private_key_type => $elasticsearch::private_key_type,
+        target           => $_keystore_path,
+        password         => $elasticsearch::keystore_password,
       }
     } else {
       $_tls_config = {}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -202,6 +202,9 @@
 # @param private_key
 #   Path to the key associated with this node's certificate.
 #
+# @param private_key_type
+#   Type of private key that will be used; see java_ks for valid options
+#
 # @param proxy_url
 #   For http and https downloads, you may set a proxy server to use. By default,
 #   no proxy is used.
@@ -401,6 +404,7 @@ class elasticsearch (
   Optional[String]                                $keystore_password         = undef,
   Optional[Stdlib::Absolutepath]                  $keystore_path             = undef,
   Optional[Stdlib::Absolutepath]                  $private_key               = undef,
+  Optional[String]                                $private_key_type          = undef,
   Boolean                                         $restart_config_change     = $restart_on_change,
   Boolean                                         $restart_package_change    = $restart_on_change,
   Boolean                                         $restart_plugin_change     = $restart_on_change,


### PR DESCRIPTION
With this PR it's now possible to set the type of the private key. If, for example, an EC private key is used, it can set with value `ec`, which will be passed to `java_ks`. The new setting is optional, when not set the current default (rsa) is used. See https://github.com/puppetlabs/puppetlabs-java_ks/blob/main/REFERENCE.md#private_key_type