### PR TITLE
regression: Fix rubocop cleanup

### DIFF
--- a/lib/puppet_x/elastic/plugin_parsing.rb
+++ b/lib/puppet_x/elastic/plugin_parsing.rb
@@ -17,7 +17,7 @@ module Puppet_X # rubocop:disable Style/ClassAndModuleCamelCase
     end
 
     # Attempt to guess at the plugin's final directory name
-    def self.plugin_split(original_string, position, soft_fail: true)
+    def self.plugin_split(original_string, position, soft_fail = true) # rubocop:disable Style/OptionalBooleanParameter
       # Try both colon (maven) and slash-delimited (github/elastic.co) names
       %w[/ :].each do |delimiter|
         parts = original_string.split(delimiter)


### PR DESCRIPTION
On master, the following code:
```puppet
elasticsearch_plugin { 'ingest-attachment':
  ensure   => 'present',
}
```

produces the following error:
```
Debug: Runtime environment: puppet_version=7.13.1, ruby_version=2.7.3, run_mode=user, default_encoding=UTF-8
Debug: Evicting cache entry for environment :production
Debug: Deleted text domain :production: false
Debug: Caching environment :production (ttl = 0 sec)
Debug: Evicting cache entry for environment :production
Debug: Deleted text domain :production: false
Debug: Facter: Resolving facts sequentially
Debug: Facter: resolving fact with user_query: osfamily
Debug: Facter: Searching fact: osfamily in file: osfamily.rb
Debug: Facter: Searching fact: osfamily in core facts and external facts
Debug: Facter: Loading all internal facts
Debug: Facter: List of resolvable facts: [#<Facter::SearchedFact:0x000055817d4a4738 @name="osfamily", @fact_class=Facts::Linux::Os::Family, @user_query="osfamily", @type=:legacy, @file=nil>]
Debug: Facter: Loading external facts
Debug: Facter: fact "osfamily" has resolved to: Debian
Debug: Loaded state in 0.08 seconds
Debug: Elasticsearch_plugin[ingest-attachment](provider=elasticsearch_plugin): ingest-attachment: exists? method in elastic_plugin.rb
Error: /Elasticsearch_plugin[ingest-attachment]: Could not evaluate: wrong number of arguments (given 3, expected 2)
Debug: Finishing transaction 10000
Debug: Storing state
Debug: Pruned old state cache entries in 0.00 seconds
Debug: Stored state in 0.03 seconds
Debug: Elasticsearch_plugin[ingest-attachment](provider=elasticsearch_plugin): ingest-attachment: exists? method in elastic_plugin.rb
Error: Could not run: wrong number of arguments (given 3, expected 2)
```

Before RuboCop went rouge, the method header looked like this:
```
def self.plugin_split(original_string, position, soft_fail = true)
```

master has `soft_fail` as a symbol and that produces the above error
messsage. This commits reverts it and it works locally for me again.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
