### PR TITLE
fix error in custom fact resolution when conf file is empty

### DIFF
--- a/lib/facter/es_facts.rb
+++ b/lib/facter/es_facts.rb
@@ -50,6 +50,8 @@ module EsFacts
 
     if File.readable?("#{dir_prefix}/elasticsearch.yml")
       config_data = YAML.load_file("#{dir_prefix}/elasticsearch.yml")
+      return unless config_data
+
       httpport, ssl = get_httpport(config_data)
     end
 


### PR DESCRIPTION

#### Pull Request (PR) description
Actually if a empty file exit the fact fail:
```
facter -p elasticsearch
2021-12-30 10:09:58.517175 ERROR puppetlabs.facter - error while resolving custom facts in /opt/puppetlabs/puppet/cache/lib/facter/es_facts.rb: undefined method `[]' for false:FalseClass
```

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
