### PR TITLE
Fix CI

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,8 @@
+# Needed for older facter to fetch facts used by the apt module
+#
+# Might be fixed by: https://github.com/puppetlabs/puppetlabs-apt/pull/1017
+if versioncmp(fact('facterversion'), '4.0.0') < 0 and fact('os.name') == 'Ubuntu' {
+  package { 'lsb-release':
+    ensure => present,
+  }
+}


### PR DESCRIPTION
Older facter bundled with Puppet 6 needs lsb-release, old Ubuntu images
seems not to ship with it anymore.
