### PR TITLE
Define default_target for parsed file providers

### DIFF
--- a/lib/puppet/provider/elastic_parsedfile.rb
+++ b/lib/puppet/provider/elastic_parsedfile.rb
@@ -9,6 +9,6 @@ class Puppet::Provider::ElasticParsedFile < Puppet::Provider::ParsedFile
   #
   # @return String
   def self.xpack_config(val)
-    @xpack_config ||= "/etc/elasticsearch/#{val}"
+    self.default_target ||= "/etc/elasticsearch/#{val}"
   end
 end

--- a/spec/unit/provider/elastic_parsedfile_spec.rb
+++ b/spec/unit/provider/elastic_parsedfile_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', 'lib'))
+
+require 'spec_helper_rspec'
+require 'puppet/provider/elastic_parsedfile'
+
+describe Puppet::Provider::ElasticParsedFile do
+  subject do
+    described_class.tap do |o|
+      o.instance_eval { @metadata = :metadata }
+    end
+  end
+
+  it { is_expected.to respond_to :default_target }
+  it { is_expected.to respond_to :xpack_config }
+
+  context 'when there is no default_target' do
+    # describe 'default_target' do
+    #   it 'returns a single whitespace' do
+    #     expect(described_class.default_target).to(eq(' '))
+    #   end
+    # end
+
+    describe 'xpack_config' do
+      value = 'somefile'
+      result = '/etc/elasticsearch/somefile'
+
+      it 'fails when no value is given' do
+        expect { described_class.xpack_config }.to raise_error(ArgumentError)
+      end
+
+      it 'defines default_target when given value' do
+        expect(described_class.xpack_config(value)).to(eq(result))
+        expect(described_class.instance_variable_get(:@default_target)).to(eq(result))
+      end
+    end
+  end
+
+  context 'whene there is a default_target' do
+    describe 'xpack_config' do
+      default_target = '/etc/elasticsearch/somefile'
+      value = 'otherfile'
+      described_class.instance_variable_set(:@default_target, default_target)
+
+      it 'fails when no value is given' do
+        expect { described_class.xpack_config }.to raise_error(ArgumentError)
+      end
+
+      it 'is idempotent' do
+        expect(described_class.xpack_config('somefile')).to(eq(default_target))
+      end
+
+      it 'still returns the previously defined target when a new value is given' do
+        expect(described_class.xpack_config(value)).to(eq(default_target))
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

Due to an automated Rubocop change in efcc297b77f729ab6658201070149fb40f8805af, the module became technically unusable if using any of the types based on `ElasticParsedFile`.

By switching the `Puppet::Provider::ElasticParsedFile#xpack_config` to return/define on `self.default_target` instead of `@xpack_config`, we fix the compilation problem caused by [an exception](https://github.com/puppetlabs/puppet/blob/093c708884397a23595a2bb6ed0dfe24a261b898/lib/puppet/provider/parsedfile.rb#L381) being triggered.

#### This Pull Request (PR) fixes the following issues

n/a