### PR TITLE
Use jvm.options.d folder on ES 7.7.0+

### DIFF
--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -412,7 +412,7 @@ describe 'elasticsearch', type: 'class' do
         }
       end
 
-      describe 'setting jvm_options' do
+      describe 'setting jvm_options before version 7.7.0' do
         jvm_options = [
           '-Xms16g',
           '-Xmx16g'
@@ -420,7 +420,8 @@ describe 'elasticsearch', type: 'class' do
 
         let(:params) do
           default_params.merge(
-            jvm_options: jvm_options
+            jvm_options: jvm_options,
+            version: '7.0.0'
           )
         end
 
@@ -434,6 +435,25 @@ describe 'elasticsearch', type: 'class' do
               )
           }
         end
+      end
+
+      describe 'setting jvm_options after version 7.7.0' do
+        jvm_options = [
+          '-Xms16g',
+          '-Xmx16g'
+        ]
+
+        let(:params) do
+          default_params.merge(
+            jvm_options: jvm_options,
+            version: '7.7.0'
+          )
+        end
+
+        it {
+          expect(subject).to contain_file('/etc/elasticsearch/jvm.options.d/jvm.options').
+            with(ensure: 'file')
+        }
       end
 
       context 'with restart_on_change => true' do
@@ -450,15 +470,30 @@ describe 'elasticsearch', type: 'class' do
           }
         end
 
-        describe 'setting jvm_options triggers restart' do
+        describe 'setting jvm_options triggers restart before version 7.7.0' do
           let(:params) do
             super().merge(
-              jvm_options: ['-Xmx16g']
+              jvm_options: ['-Xmx16g'],
+              version: '7.0.0'
             )
           end
 
           it {
             expect(subject).to contain_file_line('jvm_option_-Xmx16g').
+              that_notifies('Service[elasticsearch]')
+          }
+        end
+
+        describe 'setting jvm_options triggers restart after version 7.7.0' do
+          let(:params) do
+            super().merge(
+              jvm_options: ['-Xmx16g'],
+              version: '7.7.0'
+            )
+          end
+
+          it {
+            expect(subject).to contain_file('/etc/elasticsearch/jvm.options.d/jvm.options').
               that_notifies('Service[elasticsearch]')
           }
         end

--- a/spec/templates/002_jvm.options.erb_spec.rb
+++ b/spec/templates/002_jvm.options.erb_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'jvm.options.epp' do
+  let :harness do
+    TemplateHarness.new(
+      'templates/etc/elasticsearch/jvm.options.d/jvm.options.epp'
+    )
+  end
+
+  it 'render the same string each time' do
+    harness.set(
+      '@_sorted_jvm_options', [
+        '-Xms2g',
+        '-Xmx2g'
+      ]
+    )
+
+    first_render = harness.run
+    second_render = harness.run
+
+    expect(first_render).to eq(second_render)
+  end
+
+  it 'test content' do
+    harness.set(
+      '@_sorted_jvm_options', [
+        '-Xms2g',
+        '-Xmx2g'
+      ]
+    )
+
+    expect(harness.run).to eq(%(
+      ### MANAGED BY PUPPET ###
+      -Xms2g
+      -Xmx2g
+    ).config)
+  end
+end

--- a/templates/etc/elasticsearch/jvm.options.d/jvm.options.epp
+++ b/templates/etc/elasticsearch/jvm.options.d/jvm.options.epp
@@ -1,0 +1,4 @@
+### MANAGED BY PUPPET ###
+<% $sorted_jvm_options.each |$jvm_option| { -%>
+<%= $jvm_option %>
+<% } -%>


### PR DESCRIPTION
#### Pull Request (PR) description

Usage jvm.options.d/jvm.options for version 7.7.0+ (only)
- Editor recommendation :  "Do not modify the root jvm.options file. Use files in jvm.options.d/ instead."
- Editor documentation : https://www.elastic.co/guide/en/elasticsearch/reference/master/advanced-configuration.html#set-jvm-options
- Editor commit (7.7.0, 8.0.0 integration) : https://github.com/elastic/elasticsearch/pull/51882

#### This Pull Request (PR) fixes the following issues

- For 7.7.0+ installation, declaration jvm_options in a full puppet managed file jvm.options.d/jvm.options (don't touch original jvm.options) > No problem with old declaration/values (cause file_line usage)


#### Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)