### PR TITLE
Management jvm.options (ES V6 V7 < 7.7.0)

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -145,6 +145,7 @@ The following parameters are available in the `elasticsearch` class:
 * [`purge_configdir`](#purge_configdir)
 * [`purge_package_dir`](#purge_package_dir)
 * [`purge_secrets`](#purge_secrets)
+* [`release_type`](#release_type)
 * [`repo_stage`](#repo_stage)
 * [`restart_on_change`](#restart_on_change)
 * [`restart_config_change`](#restart_config_change)
@@ -551,6 +552,12 @@ Data type: `Boolean`
 
 Whether or not keys present in the keystore will be removed if they are not
 present in the specified secrets hash.
+
+##### <a name="release_type"></a>`release_type`
+
+Data type: `Optional[Elasticsearch::ReleaseType]`
+
+Define editor release type ('WINDOWS', 'MACOS', 'LINUX', 'DEB', 'RPM', 'MSI').
 
 ##### <a name="repo_stage"></a>`repo_stage`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -48,6 +48,7 @@ elasticsearch::proxy_url: ~
 elasticsearch::purge_configdir: false
 elasticsearch::purge_package_dir: false
 elasticsearch::purge_secrets: false
+elasticsearch::release_type: ~
 elasticsearch::repo_stage: false
 elasticsearch::restart_on_change: false
 elasticsearch::roles: {}

--- a/data/kernel/Darwin.yaml
+++ b/data/kernel/Darwin.yaml
@@ -3,3 +3,4 @@ elasticsearch::download_tool: curl -o
 elasticsearch::download_tool_insecure: curl --insecure -o
 elasticsearch::elasticsearch_user: elasticsearch
 elasticsearch::elasticsearch_group: elasticsearch
+elasticsearch::release_type: MACOS

--- a/data/kernel/Linux.yaml
+++ b/data/kernel/Linux.yaml
@@ -6,3 +6,4 @@ elasticsearch::elasticsearch_user: elasticsearch
 elasticsearch::elasticsearch_group: elasticsearch
 elasticsearch::homedir: /usr/share/elasticsearch
 elasticsearch::package_dir: /opt/elasticsearch/swdl
+elasticsearch::release_type: LINUX

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,2 +1,3 @@
 ---
 elasticsearch::defaults_location: /etc/default
+elasticsearch::release_type: DEB

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,2 +1,3 @@
 ---
 elasticsearch::defaults_location: /etc/sysconfig
+elasticsearch::release_type: RPM

--- a/data/os/Suse.yaml
+++ b/data/os/Suse.yaml
@@ -1,3 +1,4 @@
 ---
 elasticsearch::defaults_location: /etc/sysconfig
 elasticsearch::systemd_service_path: /usr/lib/systemd/system
+elasticsearch::release_type: RPM

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -217,6 +217,9 @@
 #   Whether or not keys present in the keystore will be removed if they are not
 #   present in the specified secrets hash.
 #
+# @param release_type
+#   Define editor release type ('WINDOWS', 'MACOS', 'LINUX', 'DEB', 'RPM', 'MSI').
+#
 # @param repo_stage
 #   Use stdlib stage setup for managing the repo instead of relationship
 #   ordering.
@@ -375,6 +378,7 @@ class elasticsearch (
   Boolean                                         $purge_configdir,
   Boolean                                         $purge_package_dir,
   Boolean                                         $purge_secrets,
+  Optional[Elasticsearch::ReleaseType]            $release_type,
   Variant[Boolean, String]                        $repo_stage,
   Boolean                                         $restart_on_change,
   Hash                                            $roles,

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -412,7 +412,7 @@ describe 'elasticsearch', type: 'class' do
         }
       end
 
-      describe 'setting jvm_options before version 7.7.0' do
+      describe 'setting jvm_options before version 6.0.0' do
         jvm_options = [
           '-Xms16g',
           '-Xmx16g'
@@ -421,7 +421,7 @@ describe 'elasticsearch', type: 'class' do
         let(:params) do
           default_params.merge(
             jvm_options: jvm_options,
-            version: '7.0.0'
+            version: '5.6.16'
           )
         end
 
@@ -437,15 +437,37 @@ describe 'elasticsearch', type: 'class' do
         end
       end
 
-      describe 'setting jvm_options after version 7.7.0' do
-        jvm_options = [
-          '-Xms16g',
-          '-Xmx16g'
-        ]
-
+      describe 'setting jvm_options last version 6 (6.0.0<=version<7.7.0)' do
         let(:params) do
           default_params.merge(
-            jvm_options: jvm_options,
+            jvm_options: ['-Xms16g', '-Xmx16g'],
+            version: '6.8.23'
+          )
+        end
+
+        it {
+          expect(subject).to contain_file('/etc/elasticsearch/jvm.options').
+            with(ensure: 'file')
+        }
+      end
+
+      describe 'setting default jvm_options first version 7 (6.0.0<=version<7.7.0)' do
+        let(:params) do
+          default_params.merge(
+            version: '7.0.0'
+          )
+        end
+
+        it {
+          expect(subject).to contain_file('/etc/elasticsearch/jvm.options').
+            with(ensure: 'file')
+        }
+      end
+
+      describe 'setting jvm_options after version 7.7.0' do
+        let(:params) do
+          default_params.merge(
+            jvm_options: ['-Xms16g', '-Xmx16g'],
             version: '7.7.0'
           )
         end
@@ -470,11 +492,11 @@ describe 'elasticsearch', type: 'class' do
           }
         end
 
-        describe 'setting jvm_options triggers restart before version 7.7.0' do
+        describe 'setting jvm_options triggers restart before version 6.0.0' do
           let(:params) do
             super().merge(
-              jvm_options: ['-Xmx16g'],
-              version: '7.0.0'
+              jvm_options: ['-Xms16g', '-Xmx16g'],
+              version: '5.6.16'
             )
           end
 
@@ -484,10 +506,38 @@ describe 'elasticsearch', type: 'class' do
           }
         end
 
+        describe 'setting jvm_options triggers restart last version 6 (6.0.0<=version<7.7.0)' do
+          let(:params) do
+            super().merge(
+              jvm_options: ['-Xms16g', '-Xmx16g'],
+              version: '6.8.23'
+            )
+          end
+
+          it {
+            expect(subject).to contain_file('/etc/elasticsearch/jvm.options').
+              that_notifies('Service[elasticsearch]')
+          }
+        end
+
+        describe 'setting jvm_options triggers restart first version 7 (6.0.0<=version<7.7.0)' do
+          let(:params) do
+            super().merge(
+              jvm_options: ['-Xms16g', '-Xmx16g'],
+              version: '7.0.0'
+            )
+          end
+
+          it {
+            expect(subject).to contain_file('/etc/elasticsearch/jvm.options').
+              that_notifies('Service[elasticsearch]')
+          }
+        end
+
         describe 'setting jvm_options triggers restart after version 7.7.0' do
           let(:params) do
             super().merge(
-              jvm_options: ['-Xmx16g'],
+              jvm_options: ['-Xms16g', '-Xmx16g'],
               version: '7.7.0'
             )
           end

--- a/spec/templates/002_jvm.options.erb_spec.rb
+++ b/spec/templates/002_jvm.options.erb_spec.rb
@@ -11,7 +11,7 @@ describe 'jvm.options.epp' do
 
   it 'render the same string each time' do
     harness.set(
-      '@_sorted_jvm_options', [
+      '$sorted_jvm_options', [
         '-Xms2g',
         '-Xmx2g'
       ]
@@ -25,7 +25,7 @@ describe 'jvm.options.epp' do
 
   it 'test content' do
     harness.set(
-      '@_sorted_jvm_options', [
+      '$sorted_jvm_options', [
         '-Xms2g',
         '-Xmx2g'
       ]

--- a/templates/etc/elasticsearch/jvm.options/6/jvm.options.DEB.epp
+++ b/templates/etc/elasticsearch/jvm.options/6/jvm.options.DEB.epp
@@ -1,0 +1,132 @@
+### MANAGED BY PUPPET ###
+## JVM configuration
+## Modele : elasticsearch-6.8.23.deb
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+<% $sorted_jvm_options.each |$jvm_option| { -%>
+<%= $jvm_option %>
+<% } -%>
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1 GC is only supported on JDK version 10 or later
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
+# 10-13:-XX:-UseConcMarkSweepGC
+# 10-13:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+
+## DNS cache policy
+# cache ttl in seconds for positive DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.ttl; set to -1 to cache forever
+-Des.networkaddress.cache.ttl=60
+# cache ttl in seconds for negative DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.negative ttl; set to -1 to cache
+# forever
+-Des.networkaddress.cache.negative.ttl=10
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# explicitly set the stack size
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# turn off a JDK optimization that throws away stack traces for common
+# exceptions because stack traces are important for debugging
+-XX:-OmitStackTraceInFastThrow
+
+# enable helpful NullPointerExceptions (https://openjdk.java.net/jeps/358), if
+# they are supported
+14-:-XX:+ShowCodeDetailsInExceptionMessages
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j2.formatMsgNoLookups=true
+
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=/var/lib/elasticsearch
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log
+
+## JDK 8 GC logging
+
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:/var/log/elasticsearch/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+# time/date parsing will break in an incompatible way for some date patterns and locals
+9-:-Djava.locale.providers=COMPAT
+
+# temporary workaround for C2 bug with JDK 10 on hardware with AVX-512
+10-:-XX:UseAVX=2

--- a/templates/etc/elasticsearch/jvm.options/6/jvm.options.LINUX.epp
+++ b/templates/etc/elasticsearch/jvm.options/6/jvm.options.LINUX.epp
@@ -1,0 +1,132 @@
+### MANAGED BY PUPPET ###
+## JVM configuration
+## Modele : elasticsearch-6.8.23.tar.gz
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+<% $sorted_jvm_options.each |$jvm_option| { -%>
+<%= $jvm_option %>
+<% } -%>
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1 GC is only supported on JDK version 10 or later
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
+# 10-13:-XX:-UseConcMarkSweepGC
+# 10-13:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+
+## DNS cache policy
+# cache ttl in seconds for positive DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.ttl; set to -1 to cache forever
+-Des.networkaddress.cache.ttl=60
+# cache ttl in seconds for negative DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.negative ttl; set to -1 to cache
+# forever
+-Des.networkaddress.cache.negative.ttl=10
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# explicitly set the stack size
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# turn off a JDK optimization that throws away stack traces for common
+# exceptions because stack traces are important for debugging
+-XX:-OmitStackTraceInFastThrow
+
+# enable helpful NullPointerExceptions (https://openjdk.java.net/jeps/358), if
+# they are supported
+14-:-XX:+ShowCodeDetailsInExceptionMessages
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j2.formatMsgNoLookups=true
+
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=data
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=logs/hs_err_pid%p.log
+
+## JDK 8 GC logging
+
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:logs/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+# time/date parsing will break in an incompatible way for some date patterns and locals
+9-:-Djava.locale.providers=COMPAT
+
+# temporary workaround for C2 bug with JDK 10 on hardware with AVX-512
+10-:-XX:UseAVX=2

--- a/templates/etc/elasticsearch/jvm.options/6/jvm.options.MACOS.epp
+++ b/templates/etc/elasticsearch/jvm.options/6/jvm.options.MACOS.epp
@@ -1,0 +1,132 @@
+### MANAGED BY PUPPET ###
+## JVM configuration
+## Modele : elasticsearch-6.8.23.tar.gz
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+<% $sorted_jvm_options.each |$jvm_option| { -%>
+<%= $jvm_option %>
+<% } -%>
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1 GC is only supported on JDK version 10 or later
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
+# 10-13:-XX:-UseConcMarkSweepGC
+# 10-13:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+
+## DNS cache policy
+# cache ttl in seconds for positive DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.ttl; set to -1 to cache forever
+-Des.networkaddress.cache.ttl=60
+# cache ttl in seconds for negative DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.negative ttl; set to -1 to cache
+# forever
+-Des.networkaddress.cache.negative.ttl=10
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# explicitly set the stack size
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# turn off a JDK optimization that throws away stack traces for common
+# exceptions because stack traces are important for debugging
+-XX:-OmitStackTraceInFastThrow
+
+# enable helpful NullPointerExceptions (https://openjdk.java.net/jeps/358), if
+# they are supported
+14-:-XX:+ShowCodeDetailsInExceptionMessages
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j2.formatMsgNoLookups=true
+
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=data
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=logs/hs_err_pid%p.log
+
+## JDK 8 GC logging
+
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:logs/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+# time/date parsing will break in an incompatible way for some date patterns and locals
+9-:-Djava.locale.providers=COMPAT
+
+# temporary workaround for C2 bug with JDK 10 on hardware with AVX-512
+10-:-XX:UseAVX=2

--- a/templates/etc/elasticsearch/jvm.options/6/jvm.options.RPM.epp
+++ b/templates/etc/elasticsearch/jvm.options/6/jvm.options.RPM.epp
@@ -1,0 +1,132 @@
+### MANAGED BY PUPPET ###
+## JVM configuration
+## Modele : elasticsearch-6.8.23.rpm
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+<% $sorted_jvm_options.each |$jvm_option| { -%>
+<%= $jvm_option %>
+<% } -%>
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1 GC is only supported on JDK version 10 or later
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
+# 10-13:-XX:-UseConcMarkSweepGC
+# 10-13:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+
+## DNS cache policy
+# cache ttl in seconds for positive DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.ttl; set to -1 to cache forever
+-Des.networkaddress.cache.ttl=60
+# cache ttl in seconds for negative DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.negative ttl; set to -1 to cache
+# forever
+-Des.networkaddress.cache.negative.ttl=10
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# explicitly set the stack size
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# turn off a JDK optimization that throws away stack traces for common
+# exceptions because stack traces are important for debugging
+-XX:-OmitStackTraceInFastThrow
+
+# enable helpful NullPointerExceptions (https://openjdk.java.net/jeps/358), if
+# they are supported
+14-:-XX:+ShowCodeDetailsInExceptionMessages
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j2.formatMsgNoLookups=true
+
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=/var/lib/elasticsearch
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log
+
+## JDK 8 GC logging
+
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:/var/log/elasticsearch/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+# time/date parsing will break in an incompatible way for some date patterns and locals
+9-:-Djava.locale.providers=COMPAT
+
+# temporary workaround for C2 bug with JDK 10 on hardware with AVX-512
+10-:-XX:UseAVX=2

--- a/templates/etc/elasticsearch/jvm.options/7/jvm.options.DEB.epp
+++ b/templates/etc/elasticsearch/jvm.options/7/jvm.options.DEB.epp
@@ -1,0 +1,80 @@
+### MANAGED BY PUPPET ###
+## JVM configuration
+## Modele : elasticsearch-7.6.2-amd64.deb
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+<% $sorted_jvm_options.each |$jvm_option| { -%>
+<%= $jvm_option %>
+<% } -%>
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1 GC is only supported on JDK version 10 or later
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
+# 10-13:-XX:-UseConcMarkSweepGC
+# 10-13:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+
+## JVM temporary directory
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=/var/lib/elasticsearch
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log
+
+## JDK 8 GC logging
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:/var/log/elasticsearch/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m

--- a/templates/etc/elasticsearch/jvm.options/7/jvm.options.LINUX.epp
+++ b/templates/etc/elasticsearch/jvm.options/7/jvm.options.LINUX.epp
@@ -1,0 +1,80 @@
+### MANAGED BY PUPPET ###
+## JVM configuration
+## Modele : elasticsearch-7.6.2-linux-x86_64.tar.gz
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+<% $sorted_jvm_options.each |$jvm_option| { -%>
+<%= $jvm_option %>
+<% } -%>
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1 GC is only supported on JDK version 10 or later
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
+# 10-13:-XX:-UseConcMarkSweepGC
+# 10-13:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+
+## JVM temporary directory
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=data
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=logs/hs_err_pid%p.log
+
+## JDK 8 GC logging
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:logs/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m

--- a/templates/etc/elasticsearch/jvm.options/7/jvm.options.MACOS.epp
+++ b/templates/etc/elasticsearch/jvm.options/7/jvm.options.MACOS.epp
@@ -1,0 +1,80 @@
+### MANAGED BY PUPPET ###
+## JVM configuration
+## Modele : elasticsearch-7.6.2-x86_64.rpm
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+<% $sorted_jvm_options.each |$jvm_option| { -%>
+<%= $jvm_option %>
+<% } -%>
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1 GC is only supported on JDK version 10 or later
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
+# 10-13:-XX:-UseConcMarkSweepGC
+# 10-13:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+
+## JVM temporary directory
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=data
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=logs/hs_err_pid%p.log
+
+## JDK 8 GC logging
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:logs/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m

--- a/templates/etc/elasticsearch/jvm.options/7/jvm.options.RPM.epp
+++ b/templates/etc/elasticsearch/jvm.options/7/jvm.options.RPM.epp
@@ -1,0 +1,80 @@
+### MANAGED BY PUPPET ###
+## JVM configuration
+## Modele : elasticsearch-7.6.2-x86_64.rpm
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+<% $sorted_jvm_options.each |$jvm_option| { -%>
+<%= $jvm_option %>
+<% } -%>
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1 GC is only supported on JDK version 10 or later
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
+# 10-13:-XX:-UseConcMarkSweepGC
+# 10-13:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+
+## JVM temporary directory
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=/var/lib/elasticsearch
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log
+
+## JDK 8 GC logging
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:/var/log/elasticsearch/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m

--- a/types/releasetype.pp
+++ b/types/releasetype.pp
@@ -1,0 +1,2 @@
+# List from https://www.elastic.co/fr/downloads/past-releases/elasticsearch-7-6-2
+type Elasticsearch::ReleaseType = Enum['WINDOWS', 'MACOS', 'LINUX', 'DEB', 'RPM', 'MSI']


### PR DESCRIPTION
#### Pull Request (PR) description
- Add new parameter (enum) $release_type to separate differents jvm.options (some expert settings are different between 'DEB' and 'LINUX' ...etc and between v7 and v6)
    - List of values > https://www.elastic.co/fr/downloads/past-releases/elasticsearch-7-6-2
    - Add value in "data" yaml files 
- Templates 7 are made from 7.6.2 releases
- Templates 6 are made from 6.8.23 releases
- Add code in 000_elasticsearch_init_spec.rb for the coverage 100%

Templates are in 2 parts
- first part $jvm_options (-Xms, -Xmx and others custom choices)
- second part "expert settings" : fixed values

#### This Pull Request (PR) fixes the following issues
- https://github.com/voxpupuli/puppet-elasticsearch/issues/1093
- https://github.com/voxpupuli/puppet-elasticsearch/issues/1053

#### Pull request acceptance prerequisites:

- [x] Signed the [CLA](https://www.elastic.co/contributor-agreement/) (if not already signed)
- [x] Rebased/up-to-date with base branch
- [x] Tests pass
- [ ] Updated CHANGELOG.md with patch notes (if necessary)
- [ ] Updated CONTRIBUTORS (if attribution is requested)