### PR TITLE
Fix user role mapping config file

### DIFF
--- a/lib/puppet/provider/elastic_user_roles.rb
+++ b/lib/puppet/provider/elastic_user_roles.rb
@@ -36,7 +36,7 @@ class Puppet::Provider::ElasticUserRoles < Puppet::Provider::ElasticYaml
   # Represent this user/role record as a correctly-formatted config file.
   def self.to_file(records)
     debug "Flushing: #{records.inspect}"
-    records.map do |record|
+    records = records.map do |record|
       record[:roles].map do |r|
         { [record[:name]] => r }
       end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Creation of user role mapping config file is broken, because results of hash rebuilding are not saved to a variable.

#### This Pull Request (PR) fixes the following issues
Fixes #1155