### PR TITLE
Allow change logdir mode value

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -125,6 +125,7 @@ The following parameters are available in the `elasticsearch` class:
 * [`keystore_path`](#keystore_path)
 * [`license`](#license)
 * [`logdir`](#logdir)
+* [`logdir_mode`](#logdir_mode)
 * [`logging_config`](#logging_config)
 * [`logging_file`](#logging_file)
 * [`logging_level`](#logging_level)
@@ -420,6 +421,12 @@ Optional Elasticsearch license in hash or string form.
 Data type: `Stdlib::Absolutepath`
 
 Directory that will be used for Elasticsearch logging.
+
+##### <a name="logdir_mode"></a>`logdir_mode`
+
+Data type: `String`
+
+Mode directory that will be used for Elasticsearch logging (default 2750).
 
 ##### <a name="logging_config"></a>`logging_config`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -43,7 +43,7 @@ class elasticsearch::config {
         ensure => 'directory',
         group  => $elasticsearch::elasticsearch_group,
         owner  => $elasticsearch::elasticsearch_user,
-        mode   => '2750';
+        mode   => $elasticsearch::logdir_mode;
       $elasticsearch::real_plugindir:
         ensure => 'directory',
         group  => $elasticsearch::elasticsearch_group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,6 +148,9 @@
 # @param logdir
 #   Directory that will be used for Elasticsearch logging.
 #
+# @param logdir_mode
+#   Mode directory that will be used for Elasticsearch logging (default 2750).
+#
 # @param logging_config
 #   Representation of information to be included in the log4j.properties file.
 #
@@ -404,6 +407,7 @@ class elasticsearch (
   Boolean                                         $restart_config_change     = $restart_on_change,
   Boolean                                         $restart_package_change    = $restart_on_change,
   Boolean                                         $restart_plugin_change     = $restart_on_change,
+  Stdlib::Filemode                                $logdir_mode               = '2750',
 ) {
   #### Validate parameters
 


### PR DESCRIPTION
#### Pull Request (PR) description

Add parameter logdir_mode to allow change the default value '2750' to another.

#### This Pull Request (PR) fixes the following issues

Ours logs files are on a mountpoint. Each 'puppet agent' try to change directory mode to '2750' and restart service.
But the value is fixed and don't change.
