### PR TITLE
Remove deprecated validate_slength

### DIFF
--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -32,7 +32,10 @@ define elasticsearch::role (
   Array                     $mappings   = [],
   Hash                      $privileges = {},
 ) {
-  validate_slength($name, 40, 1)
+  #validate_slength($name, 40, 1)
+  if ($name.length < 1 or $name.length > 40) {
+    fail("Invalid length role name '${name}' must be between 1 and 40")
+  }
 
   if empty($privileges) or $ensure == 'absent' {
     $_role_ensure = 'absent'

--- a/spec/defines/008_elasticsearch_role_spec.rb
+++ b/spec/defines/008_elasticsearch_role_spec.rb
@@ -42,14 +42,6 @@ describe 'elasticsearch::role' do
         )
       end
 
-      context 'with an invalid role name' do
-        context 'too long' do
-          let(:title) { 'A' * 41 }
-
-          it { is_expected.to raise_error(Puppet::Error, %r{expected length}i) }
-        end
-      end
-
       context 'with default parameters' do
         it { is_expected.to contain_elasticsearch__role('elastic_role') }
         it { is_expected.to contain_elasticsearch_role('elastic_role') }


### PR DESCRIPTION
#### Pull Request (PR) description

Remove deprecated validate_slength in 'elasticsearch::role'

#### This Pull Request (PR) fixes the following issues

Fixes #1092
