### PR TITLE
Fix usage of static `'elasticsearch'` instead of `$elasticsearch::service_name`

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -65,7 +65,7 @@ class elasticsearch::config {
         owner  => 'root',
         group  => $elasticsearch::elasticsearch_group,
         mode   => '0660',
-        before => Service['elasticsearch'],
+        before => Service[$elasticsearch::service_name],
         notify => $elasticsearch::_notify_service,
       }
     } else {
@@ -73,7 +73,7 @@ class elasticsearch::config {
         incl    => "${elasticsearch::defaults_location}/elasticsearch",
         lens    => 'Shellvars.lns',
         changes => template("${module_name}/etc/sysconfig/defaults.erb"),
-        before  => Service['elasticsearch'],
+        before  => Service[$elasticsearch::service_name],
         notify  => $elasticsearch::_notify_service,
       }
     }
@@ -230,7 +230,7 @@ class elasticsearch::config {
 
     file { "${elasticsearch::defaults_location}/elasticsearch":
       ensure    => 'absent',
-      subscribe => Service['elasticsearch'],
+      subscribe => Service[$elasticsearch::service_name],
     }
   }
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -127,7 +127,7 @@ define elasticsearch::plugin (
     proxy                      => $_proxy,
     plugin_dir                 => $elasticsearch::real_plugindir,
     plugin_path                => $module_dir,
-    before                     => Service['elasticsearch'],
+    before                     => Service[$elasticsearch::service_name],
   }
   -> file { "${elasticsearch::real_plugindir}/${_module_dir}":
     ensure  => $_file_ensure,
@@ -138,7 +138,7 @@ define elasticsearch::plugin (
 
   if $elasticsearch::restart_plugin_change {
     Elasticsearch_plugin[$name] {
-      notify +> Service['elasticsearch'],
+      notify +> Service[$elasticsearch::service_name],
     }
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

Replace static service name 'elasticsearch' by $elasticsearch::service_name

#### This Pull Request (PR) fixes the following issues

- finish PR https://github.com/voxpupuli/puppet-elasticsearch/pull/1107

When Elasticsearch is installed with a custom service_name, puppet will fail because the custom name is not used for the before relationship metaparameter.

```
class { 'elasticsearch':
  service_name        => 'elasticsearch_default',
}
```
results in:
Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Could not find resource 'Service[elasticsearch]' in parameter 'before'
