### PR TITLE
Test binary path elasticsearch-plugin

### DIFF
--- a/lib/puppet/provider/elasticsearch_plugin/ruby.rb
+++ b/lib/puppet/provider/elasticsearch_plugin/ruby.rb
@@ -17,7 +17,11 @@ Puppet::Type.type(:elasticsearch_plugin).provide(
     commands es: '/usr/local/elasticsearch/bin/elasticsearch'
     commands javapathhelper: '/usr/local/bin/javaPathHelper'
   else
-    commands plugin: '/usr/share/elasticsearch/bin/elasticsearch-plugin'
+    if File.exist? '/usr/share/elasticsearch/bin/elasticsearch-plugin'
+      commands plugin: '/usr/share/elasticsearch/bin/elasticsearch-plugin'
+    else
+      commands plugin: '/usr/share/elasticsearch/bin/plugin'
+    end
     commands es: '/usr/share/elasticsearch/bin/elasticsearch'
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

- Add test path binary 'plugin'

Ref : https://discuss.elastic.co/t/missing-plugin-command-in-elastic/61995/2 > "elasticsearch-plugin is only applicable for 5.0 and above. if you are really on 2.4 then you need to use /usr/share/elasticsearch/bin/plugin."


#### This Pull Request (PR) fixes the following issues

Fixes #1172
Fixes #1109
