### PR TITLE
Make datadir and logdir management optional

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -34,6 +34,8 @@ elasticsearch::logging_config: {}
 elasticsearch::logging_file:
 elasticsearch::logging_level: INFO
 elasticsearch::logging_template:
+elasticsearch::manage_datadir: true
+elasticsearch::manage_logdir: true
 elasticsearch::manage_repo: true
 elasticsearch::oss: false
 elasticsearch::package_dl_timeout: 600

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,16 +34,6 @@ class elasticsearch::config {
         group  => $elasticsearch::elasticsearch_group,
         owner  => $elasticsearch::elasticsearch_user,
         mode   => '2750';
-      $elasticsearch::datadir:
-        ensure => 'directory',
-        group  => $elasticsearch::elasticsearch_group,
-        owner  => $elasticsearch::elasticsearch_user,
-        mode   => '2750';
-      $elasticsearch::logdir:
-        ensure => 'directory',
-        group  => $elasticsearch::elasticsearch_group,
-        owner  => $elasticsearch::elasticsearch_user,
-        mode   => $elasticsearch::logdir_mode;
       $elasticsearch::real_plugindir:
         ensure => 'directory',
         group  => $elasticsearch::elasticsearch_group,
@@ -55,6 +45,22 @@ class elasticsearch::config {
         owner   => 'root',
         mode    => '0755',
         recurse => true;
+    }
+    if $elasticsearch::manage_datadir {
+      file { $elasticsearch::datadir:
+        ensure => 'directory',
+        group  => $elasticsearch::elasticsearch_group,
+        owner  => $elasticsearch::elasticsearch_user,
+        mode   => '2750',
+      }
+    }
+    if $elasticsearch::manage_logdir {
+      file { $elasticsearch::logdir:
+        ensure => 'directory',
+        group  => $elasticsearch::elasticsearch_group,
+        owner  => $elasticsearch::elasticsearch_user,
+        mode   => $elasticsearch::logdir_mode,
+      }
     }
 
     # Defaults file, either from file source or from hash to augeas commands

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,6 +165,12 @@
 #   Use a custom logging template - just supply the relative path, i.e.
 #   `$module/elasticsearch/logging.yml.erb`
 #
+# @param manage_datadir
+#   Enable datadir management (default true).
+#
+# @param manage_logdir
+#   Enable logdir management (default true).
+#
 # @param manage_repo
 #   Enable repo management by enabling official Elastic repositories.
 #
@@ -363,6 +369,8 @@ class elasticsearch (
   Optional[String]                                $logging_file,
   String                                          $logging_level,
   Optional[String]                                $logging_template,
+  Boolean                                         $manage_datadir,
+  Boolean                                         $manage_logdir,
   Boolean                                         $manage_repo,
   Boolean                                         $oss,
   Stdlib::Absolutepath                            $package_dir,

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -292,6 +292,60 @@ describe 'elasticsearch', type: 'class' do
 
         it { is_expected.to compile.with_all_deps }
       end
+
+      context 'When managing the datadir' do
+        let(:params) do
+          default_params.merge(
+            datadir: '/var/lib/elasticsearch-data',
+            manage_datadir: true
+          )
+        end
+
+        it {
+          expect(subject).to contain_file('/var/lib/elasticsearch-data').
+            with(ensure: 'directory')
+        }
+      end
+
+      context 'When not managing the datadir' do
+        let(:params) do
+          default_params.merge(
+            datadir: '/var/lib/elasticsearch-data',
+            manage_datadir: false
+          )
+        end
+
+        it {
+          expect(subject).not_to contain_file('/var/lib/elasticsearch-data')
+        }
+      end
+
+      context 'When managing the logdir' do
+        let(:params) do
+          default_params.merge(
+            logdir: '/var/log/elasticsearch-log',
+            manage_logdir: true
+          )
+        end
+
+        it {
+          expect(subject).to contain_file('/var/log/elasticsearch-log').
+            with(ensure: 'directory')
+        }
+      end
+
+      context 'When not managing the logdir' do
+        let(:params) do
+          default_params.merge(
+            logdir: '/var/log/elasticsearch-log',
+            manage_logdir: false
+          )
+        end
+
+        it {
+          expect(subject).not_to contain_file('/var/log/elasticsearch-log')
+        }
+      end
     end
   end
   # rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
#### Pull Request (PR) description

- Add options manage_datadir and manage_logdir

#### This Pull Request (PR) fixes the following issues

When i used mountpoint (cifs), i had conflict on directories (owner/group and mode). Puppet try to change directory properties (but he can't) and restart service every each 'puppet agent'
