### PR TITLE
fixes #1197 - add a managed file entry for jvm.options

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -181,6 +181,15 @@ class elasticsearch::config {
       mode    => '0440',
     }
 
+    file { "${elasticsearch::configdir}/jvm.options":
+      ensure  => 'file',
+      notify  => $elasticsearch::_notify_service,
+      require => Class['elasticsearch::package'],
+      owner   => $elasticsearch::elasticsearch_user,
+      group   => $elasticsearch::elasticsearch_group,
+      mode    => '0640',
+    }
+
     if ($elasticsearch::version != false and versioncmp($elasticsearch::version, '7.7.0') >= 0) {
       # https://www.elastic.co/guide/en/elasticsearch/reference/master/advanced-configuration.html#set-jvm-options
       # https://github.com/elastic/elasticsearch/pull/51882


### PR DESCRIPTION
This fixes #1197 and effectively replaces #1041 which was originally opened to support #928.  I believe this will also fix #1093.

The jvm.options file is considered a config by the RPM (would expect the same to be true of a DEB) so when migrating from a multi-instance to a single instance management and not changing versions, its possible the file `jvm.options` would not exist in the new configuration directory.  This change ensures the file exists and if not creates an empty file.