### PR TITLE
Optional keystore mgmt

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -229,7 +229,7 @@ class elasticsearch::config {
     }
 
     # Add secrets to keystore
-    if $elasticsearch::secrets != undef {
+    if ($elasticsearch::manage_secrets and $elasticsearch::secrets != undef) {
       elasticsearch_keystore { 'elasticsearch_secrets':
         configdir => $elasticsearch::configdir,
         purge     => $elasticsearch::purge_secrets,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -181,6 +181,15 @@ class elasticsearch::config {
       mode    => '0440',
     }
 
+    file { "${elasticsearch::configdir}/jvm.options":
+      ensure  => 'file',
+      notify  => $elasticsearch::_notify_service,
+      require => Class['elasticsearch::package'],
+      owner   => $elasticsearch::elasticsearch_user,
+      group   => $elasticsearch::elasticsearch_group,
+      mode    => '0640',
+    }
+
     if ($elasticsearch::version != false and versioncmp($elasticsearch::version, '7.7.0') >= 0) {
       # https://www.elastic.co/guide/en/elasticsearch/reference/master/advanced-configuration.html#set-jvm-options
       # https://github.com/elastic/elasticsearch/pull/51882

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,6 +174,9 @@
 # @param manage_repo
 #   Enable repo management by enabling official Elastic repositories.
 #
+# @param manage_secrets
+#   Enable secret management through the use of elastic-keystore.
+#
 # @param oss
 #   Whether to use the purely open source Elasticsearch package distribution.
 #
@@ -387,6 +390,7 @@ class elasticsearch (
   Boolean                                         $manage_datadir,
   Boolean                                         $manage_logdir,
   Boolean                                         $manage_repo,
+  Boolean                                         $manage_secrets,
   Boolean                                         $oss,
   Stdlib::Absolutepath                            $package_dir,
   Integer                                         $package_dl_timeout,


### PR DESCRIPTION
#### Pull Request (PR) description
This change makes managing the secrets keystore optional.  Since the code in that is still setup for instance based deployments which are no longer supported it causes failures when utilizing this module.  By making the secrets keystore management optional it buys time to fix that code while still allowing users to take advantage of the other managed aspects.

This PR is based off of #1198 as we needed both changes in our environment.

#### This Pull Request (PR) likely relates to the following issues
#1153 
#1108 
#983 

