### PR TITLE
Add owner/group to jvm.options file and Use jvm.options.d/jvm.options file by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ elasticsearch::slm_policy { 'policiyname':
 
 #### Add a new SLM policy using a file
 
-This will install and/or replace the SLM ploicy in Elasticsearch:
+This will install and/or replace the SLM policy in Elasticsearch:
 
 ```puppet
 elasticsearch::slm_policy { 'policyname':
@@ -495,7 +495,7 @@ elasticsearch::ilm_policy { 'policiyname':
 
 #### Add a new ILM policy using a file
 
-This will install and/or replace the ILM ploicy in Elasticsearch:
+This will install and/or replace the ILM policy in Elasticsearch:
 
 ```puppet
 elasticsearch::ilm_policy { 'policyname':
@@ -526,7 +526,7 @@ elasticsearch::ilm_policy { 'policyname':
 ```
 #### Delete an ILM policy
 
-This will install and/or replace the ILM ploicy in Elasticsearch:
+This will install and/or replace the ILM policy in Elasticsearch:
 
 ```puppet
 elasticsearch::ilm_policy { 'policyname':

--- a/spec/classes/000_elasticsearch_init_spec.rb
+++ b/spec/classes/000_elasticsearch_init_spec.rb
@@ -437,7 +437,7 @@ describe 'elasticsearch', type: 'class' do
         end
       end
 
-      describe 'running a a different user' do
+      describe 'running a different user' do
         let(:params) do
           default_params.merge(
             elasticsearch_user: 'myesuser',
@@ -463,6 +463,11 @@ describe 'elasticsearch', type: 'class' do
         it {
           expect(subject).to contain_file('/var/lib/elasticsearch').
             with(owner: 'myesuser', group: 'myesgroup')
+        }
+
+        it {
+          expect(subject).to contain_file('/etc/elasticsearch/jvm.options').
+            with(owner: 'root', group: 'myesgroup')
         }
       end
 


### PR DESCRIPTION
#### Pull Request (PR) description
- Add owner/group to jvm.options file (fixes 1197)
- Use jvm.options.d/jvm.options by default

#### This Pull Request (PR) fixes the following issues
- Fixes #1197
