### PR TITLE
Modify array setting[6..] to setting[6..setting.length - 1] in ruby code

### DIFF
--- a/lib/puppet/type/elasticsearch_component_template.rb
+++ b/lib/puppet/type/elasticsearch_component_template.rb
@@ -48,7 +48,7 @@ Puppet::Type.newtype(:elasticsearch_component_template) do
               val['template']['settings']['index'] = {} unless val['template']['settings'].key? 'index'
               (val['template']['settings'].keys - ['index']).each do |setting|
                 new_key = if setting.start_with? 'index.'
-                            setting[6..]
+                            setting[6..setting.length - 1]
                           else
                             setting
                           end

--- a/lib/puppet/type/elasticsearch_index_template.rb
+++ b/lib/puppet/type/elasticsearch_index_template.rb
@@ -54,7 +54,7 @@ Puppet::Type.newtype(:elasticsearch_index_template) do
                 val['template']['settings']['index'] = {} unless val['template']['settings'].key? 'index'
                 (val['template']['settings'].keys - ['index']).each do |setting|
                   new_key = if setting.start_with? 'index.'
-                              setting[6..]
+                              setting[6..setting.length - 1]
                             else
                               setting
                             end

--- a/lib/puppet/type/elasticsearch_template.rb
+++ b/lib/puppet/type/elasticsearch_template.rb
@@ -50,7 +50,7 @@ Puppet::Type.newtype(:elasticsearch_template) do
                 val['settings']['index'] = {} unless val['settings'].key? 'index'
                 (val['settings'].keys - ['index']).each do |setting|
                   new_key = if setting.start_with? 'index.'
-                              setting[6..]
+                              setting[6..setting.length - 1]
                             else
                               setting
                             end


### PR DESCRIPTION
#### Pull Request (PR) description

- Replace in ruby files array setting[6..] by setting[6..setting.length - 1]
- Replace a ':' by '=' in self.rest method (elastic_rest.rb)

#### This Pull Request (PR) fixes the following issues

Issue https://github.com/voxpupuli/puppet-elasticsearch/issues/1222
