### PR TITLE
Change license endpoint

### DIFF
--- a/lib/puppet/provider/elasticsearch_license/ruby.rb
+++ b/lib/puppet/provider/elasticsearch_license/ruby.rb
@@ -3,20 +3,19 @@
 require 'puppet/provider/elastic_rest'
 
 Puppet::Type.type(:elasticsearch_license).provide(
-  :xpack,
-  api_resource_style: :bare,
+  :ruby,
   parent: Puppet::Provider::ElasticREST,
   metadata: :content,
   metadata_pipeline: [
     ->(data) { Puppet_X::Elastic.deep_to_s data },
     ->(data) { Puppet_X::Elastic.deep_to_i data }
   ],
-  api_uri: '_xpack/license',
+  api_uri: '_license',
   query_string: {
     'acknowledge' => 'true'
   }
 ) do
-  desc 'A REST API based provider to manage Elasticsearch X-Pack licenses.'
+  desc 'A REST API based provider to manage Elasticsearch licenses.'
 
   mk_resource_methods
 

--- a/manifests/license.pp
+++ b/manifests/license.pp
@@ -72,7 +72,7 @@ class elasticsearch::license (
     port    => $api_port,
     timeout => $api_timeout,
   }
-  -> elasticsearch_license { 'xpack':
+  -> elasticsearch_license { 'license':
     ensure       => $ensure,
     content      => $_content,
     protocol     => $api_protocol,

--- a/spec/classes/006_elasticsearch_license_spec.rb
+++ b/spec/classes/006_elasticsearch_license_spec.rb
@@ -53,11 +53,11 @@ describe 'elasticsearch::license', type: 'class' do
         it do
           expect(subject).to contain_es_instance_conn_validator(
             'license-conn-validator'
-          ).that_comes_before('elasticsearch_license[xpack]')
+          ).that_comes_before('elasticsearch_license[license]')
         end
 
         it do
-          expect(subject).to contain_elasticsearch_license('xpack').with(
+          expect(subject).to contain_elasticsearch_license('license').with(
             ensure: 'present',
             content: {
               'license' => {

--- a/spec/unit/provider/elasticsearch_license/ruby_spec.rb
+++ b/spec/unit/provider/elasticsearch_license/ruby_spec.rb
@@ -2,14 +2,14 @@
 
 require_relative '../../../helpers/unit/provider/elasticsearch_rest_shared_examples'
 
-describe Puppet::Type.type(:elasticsearch_license).provider(:xpack) do # rubocop:disable RSpec/MultipleMemoizedHelpers
-  let(:name) { 'xpack' }
+describe Puppet::Type.type(:elasticsearch_license).provider(:ruby) do # rubocop:disable RSpec/MultipleMemoizedHelpers
+  let(:name) { 'ruby' }
 
   let(:example1) do
     {
-      name: 'xpack',
+      name: 'ruby',
       ensure: :present,
-      provider: :xpack,
+      provider: :ruby,
       content: {
         'license' => {
           'status' => 'active',
@@ -59,5 +59,5 @@ describe Puppet::Type.type(:elasticsearch_license).provider(:xpack) do # rubocop
     }
   end
 
-  include_examples 'REST API', 'xpack/license', nil, true
+  include_examples 'REST API', 'license', nil, true
 end


### PR DESCRIPTION
#### Pull Request (PR) description

Use the last API license endpoint format '_xpack/license' >> '_license'

- Source (v8.14) https://www.elastic.co/guide/en/elasticsearch/reference/8.14/update-license.html (same format in v7.17)
- Source (v6.8) https://www.elastic.co/guide/en/elasticsearch/reference/6.8/update-license.html (old format)

#### This Pull Request (PR) fixes the following issues

Fixes #1189

