### PR TITLE
Set xpack config to enable authentication using username and password

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -184,6 +184,7 @@ The following parameters are available in the `elasticsearch` class:
 * [`users`](#-elasticsearch--users)
 * [`validate_tls`](#-elasticsearch--validate_tls)
 * [`version`](#-elasticsearch--version)
+* [`password_enabled`](#-elasticsearch--password_enabled)
 
 ##### <a name="-elasticsearch--ensure"></a>`ensure`
 
@@ -804,6 +805,14 @@ Enable TLS/SSL validation on API calls.
 Data type: `Variant[String, Boolean]`
 
 To set the specific version you want to install.
+
+##### <a name="-elasticsearch--password_enabled"></a>`password_enabled`
+
+Data type: `Boolean`
+
+To enable or disable password authentication.
+
+Default value: `false`
 
 ### <a name="elasticsearch--config"></a>`elasticsearch::config`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -165,7 +165,7 @@ class elasticsearch::config {
 
     # Generate Elasticsearch config
     $data =
-      $elasticsearch::config + { 'path.data' => $elasticsearch::datadir } + { 'path.logs' => $elasticsearch::logdir } + $_tls_config
+      $elasticsearch::config + { 'path.data' => $elasticsearch::datadir } + { 'path.logs' => $elasticsearch::logdir } + { 'xpack.security.enabled' => $elasticsearch::password_enabled } + $_tls_config
 
     file { "${elasticsearch::configdir}/elasticsearch.yml":
       ensure  => 'file',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -343,6 +343,9 @@
 # @param version
 #   To set the specific version you want to install.
 #
+# @param password_enabled
+#   To enable or disable password authentication.
+#
 # @author Richard Pijnenburg <richard.pijnenburg@elasticsearch.com>
 # @author Tyler Langlois <tyler.langlois@elastic.co>
 # @author Gavin Williams <gavin.williams@elastic.co>
@@ -436,6 +439,7 @@ class elasticsearch (
   Boolean                                         $restart_package_change    = $restart_on_change,
   Boolean                                         $restart_plugin_change     = $restart_on_change,
   Stdlib::Filemode                                $logdir_mode               = '2750',
+  Boolean                                         $password_enabled          = false
 ) {
   #### Validate parameters
 


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request adds a `password_enabled` parameter to the Elasticsearch Puppet module to enable user/password authentication.

#### This Pull Request (PR) fixes the following issues
as there's no `xpack.security.enabled` configuration in this module I can not enable username/password authentication for Elasticsearch. So I added a parameter to make it configurable.