### PR TITLE
Drop Scientific Linux

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -48,13 +48,6 @@
       ]
     },
     {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7",
-        "8"
-      ]
-    },
-    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "11"


### PR DESCRIPTION
#### Pull Request (PR) description
Scientific Linux has been EOL since 2024-06-30